### PR TITLE
Added first version of API backend for Amazon S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ GLUSTER\_SECRET|The basic auth password you configured on the gluster api|secret
 GLUSTER\_IPS|IP addresses of the gluster endpoints|192.168.1.1,192.168.1.2
 MAX\_VOLUME\_GB|How many GB storage can a user order|100
 DDC\_API|URL of the DDC Billing API|http://ddc-api.ch
+AWS_ACCESS_KEY_ID|AWS Access Key ID to manage AWS ressources|AKIAIOSFODNN7EXAMPLE
+AWS_SECRET_ACCESS_KEY|AWS Secret Access Key to manage AWS ressources|wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+AWS_S3_BUCKET_PREFIX|Prefix for all generated S3 buckets|mycompany-
+AWS_S3_REGION|Region for new S3 buckets|eu-central-1
 
 ## The GlusterFS api
 Use/see the service unit file in ./glusterapi/install/

--- a/server/aws/iam.go
+++ b/server/aws/iam.go
@@ -1,0 +1,176 @@
+package aws
+
+import (
+	"errors"
+	"log"
+	"os"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	"github.com/oscp/cloud-selfservice-portal/server/common"
+)
+
+const (
+	genericUserCreationError = "Es ist ein Fehler bei der Erstellung des Benutzers aufgetreten"
+)
+
+// PolicyDocument IAM Policy Document
+type PolicyDocument struct {
+	Version   string
+	Statement []StatementEntry
+}
+
+// StatementEntry IAM Statement Entry
+type StatementEntry struct {
+	Effect   string
+	Action   []string
+	Resource string
+}
+
+func validateNewS3User(username string, bucketname string, newuser string) error {
+
+	if len(username) == 0 {
+		return errors.New("Username must be specified")
+	}
+	if len(bucketname) == 0 {
+		return errors.New("Bucket name must be specified")
+	}
+	if len(newuser) == 0 {
+		return errors.New("Name of new user must be specified")
+	}
+
+	if (len(newuser) + len(bucketname)) > 63 {
+		// http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html
+		return errors.New("Generierter Benutzername '" + bucketname + "-" + newuser + "' ist zu lang")
+	}
+	var validName = regexp.MustCompile(`^[a-zA-Z0-9\-]+$`).MatchString
+	if !validName(bucketname) {
+		return errors.New("Benutzername kann nur alphanumerische Zeichen und Bindestriche enthalten")
+	}
+
+	// Check if user already exists
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(os.Getenv("AWS_S3_REGION"))},
+	)
+	svc := iam.New(sess)
+	result, err := svc.ListUsers(nil)
+	if err != nil {
+		log.Print("Error while trying to create a new user (ListUsers call): " + err.Error())
+		return errors.New(genericUserCreationError)
+	}
+	// Loop over existing users
+	for _, u := range result.Users {
+		if *u.UserName == newuser {
+			log.Print("Error, user " + newuser + "already exists")
+			return errors.New("Fehler: IAM-Benutzer " + newuser + " existiert bereits")
+		}
+	}
+
+	// Make sure the user is allowed to create new IAM users for this bucket
+	myBuckets, _ := listS3BucketByUsername(username)
+	for _, mybucketname := range myBuckets.Buckets {
+		if bucketname == mybucketname {
+			// Everything OK
+			return nil
+		}
+	}
+	return errors.New("User " + username + " does not own bucket " + bucketname)
+}
+
+func createNewS3ReadUser(bucketname string, s3username string) (common.S3CredentialsResponse, error) {
+	generatedName := bucketname + "-" + s3username
+	cred, err := createNewS3User(generatedName)
+	if err != nil {
+		log.Print("Error while calling createNewS3User: " + err.Error())
+		return cred, errors.New(genericUserCreationError)
+	}
+
+	err = attachIAMPolicyToUser(bucketname+"-BucketReadPolicy", generatedName)
+	if err != nil {
+		log.Print("Error while calling attachIAMPolicyToUser: " + err.Error())
+		return cred, errors.New(genericUserCreationError)
+	}
+	return cred, nil
+}
+
+func createNewS3WriteUser(bucketname string, s3username string) (common.S3CredentialsResponse, error) {
+	generatedName := bucketname + "-" + s3username
+	cred, err := createNewS3User(generatedName)
+	if err != nil {
+		log.Print("Error while calling createNewS3User: " + err.Error())
+		return cred, errors.New(genericUserCreationError)
+	}
+
+	err = attachIAMPolicyToUser(bucketname+"-BucketWritePolicy", generatedName)
+	if err != nil {
+		log.Print("Error while calling attachIAMPolicyToUser: " + err.Error())
+		return cred, errors.New(genericUserCreationError)
+	}
+	return cred, nil
+}
+
+func createNewS3User(name string) (common.S3CredentialsResponse, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(os.Getenv("AWS_S3_REGION"))},
+	)
+
+	// Create a IAM service client.
+	svc := iam.New(sess)
+
+	_, err = svc.GetUser(&iam.GetUserInput{
+		UserName: aws.String(name),
+	})
+
+	var cred common.S3CredentialsResponse
+	if awserr, ok := err.(awserr.Error); ok && awserr.Code() == iam.ErrCodeNoSuchEntityException {
+		_, err := svc.CreateUser(&iam.CreateUserInput{
+			UserName: aws.String(name),
+		})
+
+		if err != nil {
+			return cred, errors.New("CreateUser error in createNewS3User: " + err.Error())
+		}
+
+		// Create access key
+		result, err := svc.CreateAccessKey(&iam.CreateAccessKeyInput{
+			UserName: aws.String(name),
+		})
+		cred.AccessKeyID = *result.AccessKey.AccessKeyId
+		cred.SecretKey = *result.AccessKey.SecretAccessKey
+		return cred, nil
+	}
+	return cred, errors.New("GetUser error: " + err.Error())
+}
+
+func attachIAMPolicyToUser(policyName string, username string) error {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(os.Getenv("AWS_S3_REGION"))},
+	)
+
+	// Create a IAM service client.
+	svc := iam.New(sess)
+
+	// First, figure out the AWS account ID
+	result, err := svc.GetUser(nil)
+	var accountNumber string
+	if err != nil {
+		return errors.New("GetUser error in attachIAMPolicyToUser() while trying to determine account ID: " + err.Error())
+	}
+	re := regexp.MustCompile("[0-9]+")
+	accountNumber = re.FindString(*result.User.Arn)
+
+	// Then, attach the policy given to the user
+	input := &iam.AttachUserPolicyInput{
+		PolicyArn: aws.String("arn:aws:iam::" + accountNumber + ":policy/" + policyName),
+		UserName:  aws.String(username),
+	}
+	_, err = svc.AttachUserPolicy(input)
+	if err != nil {
+		return errors.New("AttachUserPolicy error: " + err.Error())
+	}
+	return nil
+}

--- a/server/aws/s3.go
+++ b/server/aws/s3.go
@@ -1,0 +1,344 @@
+package aws
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/gin-gonic/gin"
+	"github.com/oscp/cloud-selfservice-portal/server/common"
+)
+
+const (
+	genericAPIError    = "Fehler beim Aufruf der S3-API. Bitte erstelle ein Ticket"
+	genericListError   = "Ressourcen können nicht aufgelistet werden. Bitte erstelle ein Ticket"
+	genericCreateError = "Erstellung des Buckets fehlgeschlagen. Bitte erstelle ein Ticket"
+	wrongAPIUsageError = "Invalid API call - parameters did not match to method definition"
+)
+
+// RegisterRoutes registers the routes for S3
+func RegisterRoutes(r *gin.RouterGroup) {
+	r.GET("/aws/s3/list", listS3BucketsHandler)
+	r.POST("/aws/s3/new", newS3BucketHandler)
+	r.POST("/aws/s3/newreaduser", newS3ReadUserHandler)
+	r.POST("/aws/s3/newwrite", newS3WriteUserHandler)
+}
+
+func newS3BucketHandler(c *gin.Context) {
+	username := common.GetUserName(c)
+
+	var data common.NewS3BucketCommand
+	if c.BindJSON(&data) == nil {
+
+		newbucketname := generateS3Bucketname(data.BucketName, data.Stage)
+		if err := validateNewS3Bucket(username, data.Project, newbucketname, data.Billing, data.Stage); err != nil {
+			c.JSON(http.StatusBadRequest, common.ApiResponse{Message: err.Error()})
+			return
+		}
+
+		log.Print("Creating new bucket " + newbucketname + " for " + username)
+		if err := createNewS3Bucket(username, data.Project, newbucketname, data.Billing, data.Stage); err != nil {
+			c.JSON(http.StatusBadRequest, common.ApiResponse{Message: err.Error()})
+		} else {
+			c.JSON(http.StatusOK, common.ApiResponse{
+				Message: "Es wurde ein neuer S3 Bucket erstellt: " + newbucketname,
+			})
+		}
+	} else {
+		c.JSON(http.StatusBadRequest, common.ApiResponse{Message: wrongAPIUsageError})
+	}
+}
+
+func listS3BucketsHandler(c *gin.Context) {
+	username := common.GetUserName(c)
+
+	log.Print(username + " lists S3 buckets")
+	myBuckets, _ := listS3BucketByUsername(username)
+
+	c.JSON(http.StatusOK, myBuckets)
+}
+
+func newS3ReadUserHandler(c *gin.Context) {
+	username := common.GetUserName(c)
+
+	var data common.NewS3UserCommand
+	if c.BindJSON(&data) == nil {
+
+		if err := validateNewS3User(username, data.BucketName, data.UserName); err != nil {
+			c.JSON(http.StatusBadRequest, common.ApiResponse{Message: err.Error()})
+			return
+		}
+
+		log.Print(username + " creates a new read user (" + data.UserName + ") for " + data.BucketName)
+		credentials, err := createNewS3ReadUser(data.BucketName, data.UserName)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, common.ApiResponse{Message: err.Error()})
+		} else {
+			c.JSON(http.StatusOK, credentials)
+		}
+	} else {
+		c.JSON(http.StatusBadRequest, common.ApiResponse{Message: wrongAPIUsageError})
+	}
+}
+
+func newS3WriteUserHandler(c *gin.Context) {
+	username := common.GetUserName(c)
+
+	var data common.NewS3UserCommand
+	if c.BindJSON(&data) == nil {
+
+		if err := validateNewS3User(username, data.BucketName, data.UserName); err != nil {
+			c.JSON(http.StatusBadRequest, common.ApiResponse{Message: err.Error()})
+			return
+		}
+
+		log.Print(username + " creates a new read/write user (" + data.UserName + ") for " + data.BucketName)
+		credentials, err := createNewS3WriteUser(data.BucketName, data.UserName)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, common.ApiResponse{Message: err.Error()})
+		} else {
+			c.JSON(http.StatusOK, credentials)
+		}
+	} else {
+		c.JSON(http.StatusBadRequest, common.ApiResponse{Message: wrongAPIUsageError})
+	}
+}
+
+func validateNewS3Bucket(username string, projectname string, bucketname string, billing string, stage string) error {
+
+	if len(stage) == 0 {
+		return errors.New("Umgebung muss definiert werden")
+	}
+	if len(billing) == 0 {
+		return errors.New("Verrechnungsnummer muss definiert sein")
+	}
+	if len(bucketname) == 0 {
+		return errors.New("Bucketname muss definiert sein")
+	}
+	if len(projectname) == 0 {
+		return errors.New("Projekt muss definiert sein")
+	}
+
+	if len(bucketname) > 63 {
+		// http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+		return errors.New("Generierter Bucketname " + bucketname + " ist zu lang")
+	}
+	var validName = regexp.MustCompile(`^[a-zA-Z0-9\-]+$`).MatchString
+	if !validName(bucketname) {
+		return errors.New("Bucketname kann nur alphanumerische Zeichen und Bindestriche enthalten")
+	}
+
+	if stage != "dev" && stage != "test" && stage != "int" && stage != "prod" {
+		return errors.New("Unbekannte Umgebung: " + stage)
+	}
+
+	// Check if bucket already exists
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(os.Getenv("AWS_S3_REGION"))},
+	)
+	svc := s3.New(sess)
+	result, err := svc.ListBuckets(nil)
+	if err != nil {
+		log.Print("Error while trying to validate new bucket (ListBucket call): " + err.Error())
+		return errors.New(genericCreateError)
+	}
+
+	for _, b := range result.Buckets {
+		if *b.Name == bucketname {
+			log.Print("Error, bucket " + bucketname + "already exists")
+			return errors.New("Fehler: Bucket " + bucketname + " existiert bereits")
+		}
+	}
+
+	// Everything OK
+	return nil
+}
+
+func createNewS3Bucket(username string, projectname string, bucketname string, billing string, stage string) error {
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(os.Getenv("AWS_S3_REGION"))},
+	)
+
+	// Create S3 service client
+	svc := s3.New(sess)
+
+	_, err = svc.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucketname),
+	})
+	if err != nil {
+		log.Print("Error on CreateBucket call (username=" + username + ", bucketname=" + bucketname + "): " + err.Error())
+		return errors.New(genericCreateError)
+	}
+
+	// Wait until bucket is created before finishing
+	log.Print("Waiting for bucket " + bucketname + " to be created...")
+	err = svc.WaitUntilBucketExists(&s3.HeadBucketInput{
+		Bucket: aws.String(bucketname),
+	})
+
+	if err != nil {
+		log.Print("Error when creating S3 bucket in WaitUntilBucketExists: " + err.Error())
+		return errors.New(genericCreateError)
+	}
+
+	_, err = svc.PutBucketTagging(&s3.PutBucketTaggingInput{
+		Bucket: aws.String(bucketname),
+		Tagging: &s3.Tagging{
+			TagSet: []*s3.Tag{
+				{Key: aws.String("Creator"), Value: aws.String(username)},
+				{Key: aws.String("Project"), Value: aws.String(projectname)},
+				{Key: aws.String("Accounting_Number"), Value: aws.String(billing)},
+				{Key: aws.String("Stage"), Value: aws.String(stage)},
+			},
+		}})
+	if err != nil {
+		log.Print("Tagging bucket " + bucketname + " failed: " + err.Error())
+		return errors.New(genericCreateError)
+	}
+
+	//log.Print("Creating IAM policies for bucket " + bucketname + "...")
+	// Create a IAM service client.
+	iamSvc := iam.New(sess)
+
+	readPolicy := PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []StatementEntry{
+			StatementEntry{
+				Effect: "Allow",
+				Action: []string{
+					"s3:Get*",  // Allow Get commands
+					"s3:List*", // Allow List commands
+				},
+				Resource: "arn:aws:s3:::" + bucketname,
+			},
+			StatementEntry{
+				Effect: "Allow",
+				Action: []string{
+					"s3:Get*",  // Allow Get commands
+					"s3:List*", // Allow List commands
+				},
+				Resource: "arn:aws:s3:::" + bucketname + "/*",
+			},
+		},
+	}
+
+	writePolicy := PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []StatementEntry{
+			StatementEntry{
+				Effect: "Allow",
+				Action: []string{
+					"s3:Get*",    // Allow Get commands
+					"s3:List*",   // Allow List commands
+					"s3:Put*",    // Allow Put commands
+					"s3:Delete*", // Allow Delete commands
+				},
+				Resource: "arn:aws:s3:::" + bucketname,
+			},
+			StatementEntry{
+				Effect: "Allow",
+				Action: []string{
+					"s3:Get*",    // Allow Get commands
+					"s3:List*",   // Allow List commands
+					"s3:Put*",    // Allow Put commands
+					"s3:Delete*", // Allow Delete commands
+				},
+				Resource: "arn:aws:s3:::" + bucketname + "/*",
+			},
+		},
+	}
+
+	// Read policy
+	b, err := json.Marshal(&readPolicy)
+	if err != nil {
+		log.Print("Error marshaling readPolicy: " + err.Error())
+		return errors.New(genericCreateError)
+	}
+
+	_, err = iamSvc.CreatePolicy(&iam.CreatePolicyInput{
+		PolicyDocument: aws.String(string(b)),
+		PolicyName:     aws.String(bucketname + "-BucketReadPolicy"),
+	})
+	if err != nil {
+		log.Print("Error CreatePolicy for BucketReadPolicy failed: " + err.Error())
+		return errors.New(genericCreateError)
+	}
+
+	// Write policy
+	c, err := json.Marshal(&writePolicy)
+	if err != nil {
+		log.Print("Error marshaling writePolicy: " + err.Error())
+		return errors.New(genericCreateError)
+	}
+
+	_, err = iamSvc.CreatePolicy(&iam.CreatePolicyInput{
+		PolicyDocument: aws.String(string(c)),
+		PolicyName:     aws.String(bucketname + "-BucketWritePolicy"),
+	})
+	if err != nil {
+		log.Print("Error CreatePolicy for BucketWritePolicy failed: " + err.Error())
+		return errors.New(genericCreateError)
+	}
+
+	log.Print("Bucket " + bucketname + " and IAM policies successfully created")
+	return nil
+}
+
+func generateS3Bucketname(bucketname string, stage string) string {
+	// Generate bucketname: <prefix>-<bucketname>-<stage_suffix>
+	bucketPrefix := os.Getenv("AWS_S3_BUCKET_PREFIX")
+	stageSuffix := "nonprod"
+	if stage == "prod" {
+		stageSuffix = "prod"
+	}
+	return strings.ToLower(bucketPrefix + bucketname + "-" + stageSuffix)
+}
+
+func listS3BucketByUsername(username string) (common.BucketListResponse, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(os.Getenv("AWS_S3_REGION"))},
+	)
+
+	// Create S3 service client
+	svc := s3.New(sess)
+
+	result, err := svc.ListBuckets(nil)
+	if err != nil {
+		log.Print("Unable to list buckets (ListBuckets API call): " + err.Error())
+		return common.BucketListResponse{}, errors.New(genericListError)
+	}
+
+	// Return list
+	responseList := common.BucketListResponse{
+		Buckets: []string{},
+	}
+
+	for _, b := range result.Buckets {
+		// Get bucket tags
+		taggingParams := &s3.GetBucketTaggingInput{
+			Bucket: aws.String(*b.Name),
+		}
+		result, err := svc.GetBucketTagging(taggingParams)
+		if err != nil {
+			log.Print("Unable to get tags for bucket, username " + username + ": " + err.Error())
+			return common.BucketListResponse{}, errors.New(genericListError)
+		}
+
+		// Get list of buckets where "Creator" equals username and return only those
+		for _, tag := range result.TagSet {
+			if *tag.Key == "Creator" && *tag.Value == username {
+				responseList.Buckets = append(responseList.Buckets, *b.Name)
+			}
+		}
+	}
+	return responseList, nil
+}

--- a/server/common/apimodels.go
+++ b/server/common/apimodels.go
@@ -56,26 +56,49 @@ type ApiResponse struct {
 	Message string `json:"message"`
 }
 
+type BucketListResponse struct {
+	Buckets []string `json:"buckets"`
+}
+
+type S3CredentialsResponse struct {
+	Username    string `json:"username"`
+	AccessKeyID string `json:"accesskeyid"`
+	SecretKey   string `json:"secretkey"`
+}
+
 type AdminList struct {
 	Admins []string `json:"admins"`
 }
 
 type DDCBilling struct {
 	Rows []DDCBillingRow `json:"rows"`
-	CSV  string `json:"csv"`
+	CSV  string          `json:"csv"`
 }
 
 type DDCBillingRow struct {
-	Sender              string `json:"sender"`
-	Art                 string `json:"art"`
-	Project             string `json:"project"`
-	Host                string `json:"host"`
-	Backup              bool   `json:"backup"`
-	ReceptionAssignment string `json:"receptionAssignment"`
-	OrderReception      string `json:"orderReception"`
-	PspElement          string `json:"pspElement"`
+	Sender              string  `json:"sender"`
+	Art                 string  `json:"art"`
+	Project             string  `json:"project"`
+	Host                string  `json:"host"`
+	Backup              bool    `json:"backup"`
+	ReceptionAssignment string  `json:"receptionAssignment"`
+	OrderReception      string  `json:"orderReception"`
+	PspElement          string  `json:"pspElement"`
 	TotalCPU            float64 `json:"totalCpu"`
 	TotalMemory         float64 `json:"totalMemory"`
 	TotalStorage        float64 `json:"totalStorage"`
 	Total               float64 `json:"total"`
+}
+
+type NewS3BucketCommand struct {
+	ProjectName
+	BucketName string `json:"bucketname"`
+	Billing    string `json:"billing"`
+	Stage      string `json:"stage"`
+}
+
+type NewS3UserCommand struct {
+	ProjectName
+	BucketName string `json:"bucketname"`
+	UserName   string `json:"username"`
 }

--- a/server/main.go
+++ b/server/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/oscp/cloud-selfservice-portal/server/aws"
 	"github.com/oscp/cloud-selfservice-portal/server/common"
 	"github.com/oscp/cloud-selfservice-portal/server/ddc"
 	"github.com/oscp/cloud-selfservice-portal/server/openshift"
@@ -33,6 +34,9 @@ func main() {
 
 		// DDC routes
 		ddc.RegisterRoutes(auth)
+
+		// AWS routes
+		aws.RegisterRoutes(auth)
 	}
 
 	log.Println("Cloud SSP is running")


### PR DESCRIPTION
As a new feature, the cloud-selfservice-portal is now able to provision AWS resources. In this first version, the portal can be used to create new Amazon S3 buckets.

When provisioning new buckets, the portal creates a new S3 bucket and corresponding "ReadPolicy" and "WritePolicy" IAM policies. These policies can the be attached to new users with the relevant functions.